### PR TITLE
Too many open files bug

### DIFF
--- a/scripts/test-with-different-input.sh
+++ b/scripts/test-with-different-input.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# for testing multiple PDFs sent accross to the service
+
+# copy pdf file to file
+file="/tmp/striky-$(date +%s)${RANDOM}"
+
+cp ../form.pdf ${file}.pdf
+
+# write the below JSON to a file
+cat <<EOF > ${file}.json
+{
+    "input": "${file}.pdf",
+    "output": "/tmp/blah.pdf",
+    "strikes": [
+        { "page": 2, "x": 267, "y": 557, "x1": 40, "y1": 0, "thickness": 2 },
+        { "page": 2, "x": 309, "y": 557, "x1": 37, "y1": 0, "thickness": 2 }
+    ],
+    "flatten": true
+}
+EOF
+
+# post the request
+curl -H "Accept: application/json" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d @scripts/${file}.json http://127.0.0.1:4000/

--- a/scripts/test-with-different-input.sh
+++ b/scripts/test-with-different-input.sh
@@ -2,10 +2,12 @@
 
 # for testing multiple PDFs sent accross to the service
 
+echo "run this script from the repo's root directory" >&2
+
 # copy pdf file to file
 file="/tmp/striky-$(date +%s)${RANDOM}"
 
-cp ../form.pdf ${file}.pdf
+cp form.pdf ${file}.pdf
 
 # write the below JSON to a file
 cat <<EOF > ${file}.json
@@ -24,4 +26,4 @@ EOF
 curl -H "Accept: application/json" \
     -X POST \
     -H "Content-Type: application/json" \
-    -d @scripts/${file}.json http://127.0.0.1:4000/
+    -d @${file}.json http://127.0.0.1:4000/

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,7 @@
+#!/bin/sh
 # test the app manually
 
 curl -H "Accept: application/json" \
     -X POST \
     -H "Content-Type: application/json" \
-    -d @scripts/strikes.json http://localhost:4000/
+    -d @scripts/strikes.json http://127.0.0.1:4000/

--- a/src/strike2/cross_out.clj
+++ b/src/strike2/cross_out.clj
@@ -118,7 +118,9 @@
         (do-strikes strikes pdf-content)
         (info "Done with strikes, moving onto flattening...")
         (if (true? (flatten-pdf pdf-content parsed-data))
-          (two-oh-oh new-pdf-file)
+          (do
+            (info ".......... flattening" new-pdf-file)
+            (two-oh-oh new-pdf-file))
           (do
             (five-oh-oh parsed-data)
             (save-pdf pdf-file))))

--- a/src/strike2/cross_out.clj
+++ b/src/strike2/cross_out.clj
@@ -126,4 +126,7 @@
         (do
           (info (str "Exception caught " e))
           (five-oh-oh parsed-data)))
-      (finally (info (create-message "<" "request end"))))))
+      (finally
+        (do
+          (close-reader pdf-file)
+          (info (create-message "<" "request end")))))))

--- a/src/strike2/cross_out.clj
+++ b/src/strike2/cross_out.clj
@@ -10,6 +10,10 @@
   "get PDF file reader"
   (PdfReader. pdf-file))
 
+(defn close-reader [reader]
+  "close PDF file reader"
+  (.close reader))
+
 (defn make-writer [reader file-name]
   "create PDF file writer"
   (PdfStamper. reader (FileOutputStream. file-name)))


### PR DESCRIPTION
This pull request fixes the outstanding issue where some file handlers weren't being closed, causing the app to consume all file handlers given to the Java process and eventually failing.

The solution :trophy: was the closing of the input PDF file which is used to create the new PDF file with appropriate sections crossed off.


:memo: NOTE: once this is merged into master a new tag will have to be created.
