### PR TITLE
500 properly

### DIFF
--- a/src/strike2/cross_out.clj
+++ b/src/strike2/cross_out.clj
@@ -110,7 +110,9 @@
           (do
             (info ".......... flattening" new-pdf-file)
             (two-oh-oh new-pdf-file))
-          (five-oh-oh parsed-data)))
+          (do
+            (info "No flattening instructions given, bombing out!")
+            (five-oh-oh parsed-data))))
       (catch Exception e
         (do
           (info (str "Exception caught " e))

--- a/src/strike2/cross_out.clj
+++ b/src/strike2/cross_out.clj
@@ -73,17 +73,6 @@
    :headers {"Content-Type" "application/json; charset=utf-8"}
    :body (str "error processing payload: " data)})
 
-(defn save-pdf
-  "save PDF for debugging purposes"
-  [pdf-file]
-  (let [directory (str "/var/tmp/strike2-debug-" (System/currentTimeMillis))
-        file (str directory "/" "file.pdf")]
-  (.mkdir (File. directory))
-  (clojure.java.io/copy
-   (clojure.java.io/file pdf-file)
-   (clojure.java.io/file file))
-  (info "saved file" pdf-file "as" file "for debugging")))
-
 (defn strike-out
   "Data should look like:
 
@@ -121,9 +110,7 @@
           (do
             (info ".......... flattening" new-pdf-file)
             (two-oh-oh new-pdf-file))
-          (do
-            (five-oh-oh parsed-data)
-            (save-pdf pdf-file))))
+          (five-oh-oh parsed-data)))
       (catch Exception e
         (do
           (info (str "Exception caught " e))


### PR DESCRIPTION
Removed the unused function which was there only for debugging purposes and it never got used.

Log the reason why 500 is being returned.
